### PR TITLE
preferences for API Key added

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,15 @@
       "mode": "view"
     }
   ],
+  "preferences": [
+    {
+      "name": "togglTrackApiKey",
+      "title": "Toggl Track API Key",
+      "description": "Your Toggl Track API Key",
+      "type": "password",
+      "required": true
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.77.3"
   },


### PR DESCRIPTION
Added preference for API Key. It will ask for API Key before the first use, as the API Key is required for the Toggl Track integration. 
<img width="886" alt="image" src="https://github.com/rifatc/raycast-toggl-track-extension/assets/77101056/96c8862f-e197-49d1-aa46-35a193f1376b">
