### PR TITLE
prepopulate the timer form with last timer

### DIFF
--- a/src/StartTimerForm.tsx
+++ b/src/StartTimerForm.tsx
@@ -1,6 +1,7 @@
-import { ActionPanel, Action, Form } from "@raycast/api";
+import { ActionPanel, Action, Form, LocalStorage } from "@raycast/api";
 import { useFetch } from "@raycast/utils";
 import { getPreferenceValues } from "@raycast/api";
+import { useEffect, useState } from "react";
 
 interface Workspace {
   id: number;
@@ -15,9 +16,17 @@ interface StartTimerFormProps {
   onSubmit: (title: string, workspaceId: number) => void;
 }
 
+interface LastTimer {
+  title: string;
+  workspaceId: number;
+}
+
 export function StartTimerForm({ onSubmit }: StartTimerFormProps) {
   const preferences = getPreferenceValues<Preferences>();
   const apiKey = preferences.togglTrackApiKey;
+
+  const [lastTimer, setLastTimer] = useState<LastTimer | null>(null);
+  const [isLoadingLastTimer, setIsLoadingLastTimer] = useState(true);
 
   const { data, isLoading } = useFetch<Workspace[]>("https://api.track.toggl.com/api/v9/workspaces", {
     headers: {
@@ -26,9 +35,24 @@ export function StartTimerForm({ onSubmit }: StartTimerFormProps) {
     }
   });
 
+  useEffect(() => {
+    async function fetchLastTimer() {
+      setIsLoadingLastTimer(true);
+      const storedLastTimer = await LocalStorage.getItem<string>("lastTimer");
+      if (storedLastTimer) {
+        setLastTimer(JSON.parse(storedLastTimer));
+      }
+      setIsLoadingLastTimer(false);
+    }
+    fetchLastTimer();
+  }, []);
+
+  if (isLoadingLastTimer || isLoading) {
+    return <Form isLoading={true} />;
+  }
+
   return (
     <Form
-      isLoading={isLoading}
       actions={
         <ActionPanel>
           <Action.SubmitForm
@@ -40,8 +64,17 @@ export function StartTimerForm({ onSubmit }: StartTimerFormProps) {
         </ActionPanel>
       }
     >
-      <Form.TextField id="title" title="Title" placeholder="Enter timer title" />
-      <Form.Dropdown id="workspace" title="Workspace">
+      <Form.TextField
+        id="title"
+        title="Title"
+        placeholder="Enter timer title"
+        defaultValue={lastTimer?.title || ""}
+      />
+      <Form.Dropdown
+        id="workspace"
+        title="Workspace"
+        defaultValue={lastTimer?.workspaceId?.toString() || ""}
+      >
         {data?.map((workspace) => (
           <Form.Dropdown.Item key={workspace.id} value={workspace.id.toString()} title={workspace.name} />
         ))}


### PR DESCRIPTION
For better UX, we are setting the `title` and `workspaceId` from the last timer. It will help to resume the last timer and improve user experience. 
<img width="886" alt="image" src="https://github.com/rifatc/raycast-toggl-track-extension/assets/77101056/425e923f-cc4b-4f55-a2d2-3b39de3dfa91">
